### PR TITLE
Fix for "hmset expected value to be a string" error

### DIFF
--- a/routes/data.js
+++ b/routes/data.js
@@ -7,7 +7,7 @@ var db = app.db;
  */
 
 app.on('screenshot', function(url, path, id){
-  var now = Date.now();
+  var now = "" + Date.now();
   console.log('screenshot - saving meta-data');
   db.hset('screenshot:url:id', url, id);
   db.zadd('screenshot:ids', now, id);


### PR DESCRIPTION
Error:
ubuntu@x:~/screenshot-app$ node app
Express server listening on port 3000
screenshot - rasterizing http://twitter.com 1024x600
screenshot - rasterized http://twitter.com
screenshot - saving meta-data

/home/ubuntu/screenshot-app/node_modules/redis/index.js:952
                else throw err;
                           ^
Error: hmset expected value to be a string
    at RedisClient.hmset
(/home/ubuntu/screenshot-app/node_modules/redis/index.js:950:27)
    at Function.<anonymous>
(/home/ubuntu/screenshot-app/routes/data.js:16:6)
    at Function.EventEmitter.emit (events.js:117:20)
    at /home/ubuntu/screenshot-app/routes/main.js:100:9
    at ChildProcess.exithandler (child_process.js:635:7)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at maybeClose (child_process.js:735:16)
    at Process.ChildProcess._handle.onexit (child_process.js:802:5)

Fix: Set Date.now() to be a string.
