### PR TITLE
Updates to make screenshot-app work with Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,30 +6,31 @@
 var express = require('express')
   , stylus = require('stylus')
   , redis = require('redis')
-  , http = require('http');
+  , http = require('http')
+  , logger = require('morgan')
+  , errorHandler = require('errorhandler');
 
 app = express();
 
-app.configure(function(){
-  app.db = redis.createClient();
-  app.set('views', __dirname + '/views');
-  app.set('view engine', 'jade');
-  app.set('phantom', 'phantomjs');
-  app.set('screenshots', '/tmp');
-  app.set('default viewport width', 1024);
-  app.set('default viewport height', 600);
-  app.set('colors', 3);
-  app.set('root', __dirname);
-  app.use(express.favicon());
-  app.use(express.logger('dev'));
-  app.use(stylus.middleware({ src: __dirname + '/public' }));
-  app.use(express.static(__dirname + '/public'));
-  app.use(app.router);
-});
 
-app.configure('development', function(){
-  app.use(express.errorHandler()); 
-});
+app.db = redis.createClient();
+app.set('views', __dirname + '/views');
+app.set('view engine', 'jade');
+app.set('phantom', 'phantomjs');
+app.set('screenshots', '/tmp');
+app.set('default viewport width', 1024);
+app.set('default viewport height', 600);
+app.set('colors', 3);
+app.set('root', __dirname);
+app.use(logger);
+app.use(stylus.middleware({ src: __dirname + '/public' }));
+app.use(express.static(__dirname + '/public'));
+
+
+
+
+app.use(errorHandler()); 
+
 
 require('./routes');
 

--- a/app.js
+++ b/app.js
@@ -22,7 +22,7 @@ app.set('default viewport width', 1024);
 app.set('default viewport height', 600);
 app.set('colors', 3);
 app.set('root', __dirname);
-app.use(logger);
+app.use(logger('dev'));
 app.use(stylus.middleware({ src: __dirname + '/public' }));
 app.use(express.static(__dirname + '/public'));
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
       "express": "https://github.com/visionmedia/express/tarball/master"
     , "jade": "*"
     , "palette": "*"
+    , "morgan": "*"
+    , "errorhandler": "*"
     , "redis": "0.7.x"
     , "canvas": "~1.1.2"
     , "stylus": "0.21.x"


### PR DESCRIPTION
Hi tj,

The code in your screenshot-app was written back in the Express 3 days.  It doesn't work with Express 4 in its current form due to a number of changes.  I have fixed these issues and tested them to ensure everything runs now. I made the required minimal adaptations to make it run under the latest version of Express.  Only 2 files required modification.
- First app.js no longer has the app.configure( ... ) syntax to accommodate the removal of the configure method in express.  
- Finally, Express no longer has built-in middleware for errorHandling and logging. I simply required them in and used the modules using the new style.  These modules were added to package.json to make everything work cleanly.

Requesting that you accept this pull request to keep your repo current.

Thanks,

Jclosure 
